### PR TITLE
Handle malformed dynamic sizing metadata

### DIFF
--- a/meshgraphnets/dataset.py
+++ b/meshgraphnets/dataset.py
@@ -18,10 +18,23 @@
 import functools
 import json
 import os
+import re
 
 import tensorflow.compat.v1 as tf
 
 from meshgraphnets.common import NodeType
+
+
+_DTYPE_RE = re.compile(r"^<dtype: '([^']+)'>$", re.ASCII)
+
+
+def _as_dtype(dtype):
+  """Converts metadata dtype values to TensorFlow dtypes."""
+  if isinstance(dtype, str):
+    match = _DTYPE_RE.fullmatch(dtype)
+    if match:
+      dtype = match.group(1)
+  return tf.as_dtype(dtype)
 
 
 def _parse(proto, meta):
@@ -31,16 +44,30 @@ def _parse(proto, meta):
   features = tf.io.parse_single_example(proto, feature_lists)
   out = {}
   for key, field in meta['features'].items():
-    data = tf.io.decode_raw(features[key].values, getattr(tf, field['dtype']))
-    data = tf.reshape(data, field['shape'])
-    if field['type'] == 'static':
-      data = tf.tile(data, [meta['trajectory_length'], 1, 1])
-    elif field['type'] == 'dynamic_varlen':
+    data = tf.io.decode_raw(features[key].values, _as_dtype(field['dtype']))
+    if field['type'] == 'dynamic_varlen':
       length = tf.io.decode_raw(features['length_'+key].values, tf.int32)
       length = tf.reshape(length, [-1])
+      # The number of variable-length rows is encoded independently, so for
+      # two-dimensional fields the trailing width can be inferred from the
+      # serialized data instead of relying on a potentially stale value in
+      # metadata.
+      if len(field['shape']) == 2 and field['shape'][0] == -1:
+        row_count = tf.reduce_sum(length)
+        feature_width = tf.cond(
+            tf.equal(row_count, 0),
+            lambda: tf.constant(field['shape'][1], dtype=tf.int32),
+            lambda: tf.math.floordiv(tf.size(data), row_count))
+        data = tf.reshape(data, tf.stack([row_count, feature_width]))
+      else:
+        data = tf.reshape(data, field['shape'])
       data = tf.RaggedTensor.from_row_lengths(data, row_lengths=length)
-    elif field['type'] != 'dynamic':
-      raise ValueError('invalid data format')
+    else:
+      data = tf.reshape(data, field['shape'])
+      if field['type'] == 'static':
+        data = tf.tile(data, [meta['trajectory_length'], 1, 1])
+      elif field['type'] != 'dynamic':
+        raise ValueError('invalid data format')
     out[key] = data
   return out
 

--- a/meshgraphnets/dataset_test.py
+++ b/meshgraphnets/dataset_test.py
@@ -1,0 +1,75 @@
+# pylint: disable=g-bad-file-header
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or  implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for MeshGraphNets dataset parsing."""
+
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+from meshgraphnets import dataset
+
+
+class DatasetTest(tf.test.TestCase):
+
+  def _parse_sizing_field(self, values, lengths):
+    example = tf.train.Example(features=tf.train.Features(feature={
+        'sizing_field': tf.train.Feature(
+            bytes_list=tf.train.BytesList(value=[values.tobytes()])),
+        'length_sizing_field': tf.train.Feature(
+            bytes_list=tf.train.BytesList(value=[lengths.tobytes()])),
+    })).SerializeToString()
+    meta = {
+        'field_names': ['sizing_field', 'length_sizing_field'],
+        'features': {
+            'sizing_field': {
+                'type': 'dynamic_varlen',
+                'shape': [-1, 4],
+                'dtype': "<dtype: 'float32'>",
+            },
+        },
+    }
+    return dataset._parse(tf.convert_to_tensor(example), meta)['sizing_field']
+
+  def test_dynamic_varlen_tolerates_legacy_metadata(self):
+    values = np.array([
+        [1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0],
+        [7.0, 8.0, 9.0],
+    ], dtype=np.float32)
+    lengths = np.array([2, 1], dtype=np.int32)
+
+    parsed = self._parse_sizing_field(values, lengths)
+
+    with self.session() as sess:
+      result = sess.run(parsed)
+
+    self.assertAllClose(result.values, values)
+    self.assertAllEqual(result.row_splits, [0, 2, 3])
+
+  def test_dynamic_varlen_allows_empty_rows(self):
+    values = np.empty((0, 3), dtype=np.float32)
+    lengths = np.array([0, 0], dtype=np.int32)
+
+    parsed = self._parse_sizing_field(values, lengths)
+
+    with self.session() as sess:
+      result = sess.run(parsed)
+
+    self.assertEqual(result.values.shape[0], 0)
+    self.assertAllEqual(result.row_splits, [0, 0, 0])
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
## Summary

Make the MeshGraphNets dataset loader tolerate the malformed dynamic-sizing metadata reported in #651 without hard-coding specific dataset names.

The published `flag_dynamic_sizing` and `sphere_dynamic_sizing` metadata can encode `sizing_field` with two independent problems:

- the dtype is serialized as a TensorFlow repr string such as `<dtype: 'float32'>`, which cannot be resolved through the existing `getattr(tf, ...)` path
- the two-dimensional `dynamic_varlen` shape can contain a stale trailing width (`[-1, 4]`) even though the serialized values have width 3

This change:

- normalizes TensorFlow repr-style dtype strings before passing them through `tf.as_dtype`
- uses the separately encoded row lengths to infer the trailing width of two-dimensional `dynamic_varlen` fields
- preserves explicit reshaping for other field shapes and the existing handling of static and dynamic fields
- handles empty variable-length rows without relying on an ambiguous `[0, -1]` reshape
- adds regression coverage for both the malformed metadata and an empty-row case

Fixes #651.

## Validation

Added `meshgraphnets/dataset_test.py` with focused synthetic `tf.train.Example` regression cases covering the malformed metadata properties and empty variable-length rows.

I could not execute the TensorFlow regression tests locally in this environment because TensorFlow is not installed. No local test execution is claimed. The final branch is based on current upstream `master`, contains one commit, and the diff was audited to contain only the loader change and its regression tests.