### PR TITLE
Support configurable MeshGraphNets rollout lengths

### DIFF
--- a/meshgraphnets/cfd_eval.py
+++ b/meshgraphnets/cfd_eval.py
@@ -43,19 +43,37 @@ def _rollout(model, initial_state, num_steps):
   return output.stack()
 
 
-def evaluate(model, inputs):
+def _resize_static_trajectory_field(field, num_steps):
+  """Trims or extends a static mesh field to match a rollout length."""
+  field_steps = field.shape.as_list()[0]
+  if num_steps <= field_steps:
+    return field[:num_steps]
+  extra_steps = num_steps - field_steps
+  return tf.concat(
+      [field, tf.tile(field[-1:], [extra_steps, 1, 1])], axis=0)
+
+
+def evaluate(model, inputs, num_steps=None):
   """Performs model rollouts and create stats."""
   initial_state = {k: v[0] for k, v in inputs.items()}
-  num_steps = inputs['cells'].shape[0]
+  ground_truth_steps = inputs['cells'].shape.as_list()[0]
+  if num_steps is None:
+    num_steps = ground_truth_steps
+  if num_steps <= 0:
+    raise ValueError('num_steps must be positive.')
   prediction = _rollout(model, initial_state, num_steps)
 
-  error = tf.reduce_mean((prediction - inputs['velocity'])**2, axis=-1)
+  comparison_steps = min(num_steps, ground_truth_steps)
+  error = tf.reduce_mean(
+      (prediction[:comparison_steps] -
+       inputs['velocity'][:comparison_steps])**2,
+      axis=-1)
   scalars = {'mse_%d_steps' % horizon: tf.reduce_mean(error[1:horizon+1])
              for horizon in [1, 10, 20, 50, 100, 200]}
   traj_ops = {
-      'faces': inputs['cells'],
-      'mesh_pos': inputs['mesh_pos'],
-      'gt_velocity': inputs['velocity'],
+      'faces': _resize_static_trajectory_field(inputs['cells'], num_steps),
+      'mesh_pos': _resize_static_trajectory_field(inputs['mesh_pos'], num_steps),
+      'gt_velocity': inputs['velocity'][:comparison_steps],
       'pred_velocity': prediction
   }
   return scalars, traj_ops

--- a/meshgraphnets/cfd_eval_test.py
+++ b/meshgraphnets/cfd_eval_test.py
@@ -1,0 +1,69 @@
+# pylint: disable=g-bad-file-header
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or  implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for CFD rollout evaluation."""
+
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+from meshgraphnets import cfd_eval
+from meshgraphnets.common import NodeType
+
+
+class _IncrementVelocityModel:
+
+  def __call__(self, inputs):
+    return inputs['velocity'] + tf.ones_like(inputs['velocity'])
+
+
+class CfdEvalTest(tf.test.TestCase):
+
+  def _inputs(self):
+    return {
+        'cells': tf.constant(
+            np.zeros((3, 1, 3), dtype=np.int32)),
+        'mesh_pos': tf.constant(
+            np.zeros((3, 2, 2), dtype=np.float32)),
+        'velocity': tf.constant(
+            np.zeros((3, 2, 2), dtype=np.float32)),
+        'node_type': tf.constant(
+            np.full((3, 2, 1), NodeType.NORMAL, dtype=np.int32)),
+    }
+
+  def test_default_rollout_uses_ground_truth_length(self):
+    _, trajectory = cfd_eval.evaluate(
+        _IncrementVelocityModel(), self._inputs())
+
+    with self.session() as sess:
+      prediction = sess.run(trajectory['pred_velocity'])
+
+    self.assertEqual(prediction.shape[0], 3)
+
+  def test_long_rollout_extends_prediction_and_static_mesh(self):
+    _, trajectory = cfd_eval.evaluate(
+        _IncrementVelocityModel(), self._inputs(), num_steps=5)
+
+    with self.session() as sess:
+      result = sess.run(trajectory)
+
+    self.assertEqual(result['pred_velocity'].shape[0], 5)
+    self.assertEqual(result['faces'].shape[0], 5)
+    self.assertEqual(result['mesh_pos'].shape[0], 5)
+    self.assertEqual(result['gt_velocity'].shape[0], 3)
+    self.assertAllClose(result['pred_velocity'][:, 0, 0], [0, 1, 2, 3, 4])
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/meshgraphnets/cloth_eval.py
+++ b/meshgraphnets/cloth_eval.py
@@ -42,19 +42,37 @@ def _rollout(model, initial_state, num_steps):
   return output.stack()
 
 
-def evaluate(model, inputs):
+def _resize_static_trajectory_field(field, num_steps):
+  """Trims or extends a static mesh field to match a rollout length."""
+  field_steps = field.shape.as_list()[0]
+  if num_steps <= field_steps:
+    return field[:num_steps]
+  extra_steps = num_steps - field_steps
+  return tf.concat(
+      [field, tf.tile(field[-1:], [extra_steps, 1, 1])], axis=0)
+
+
+def evaluate(model, inputs, num_steps=None):
   """Performs model rollouts and create stats."""
   initial_state = {k: v[0] for k, v in inputs.items()}
-  num_steps = inputs['cells'].shape[0]
+  ground_truth_steps = inputs['cells'].shape.as_list()[0]
+  if num_steps is None:
+    num_steps = ground_truth_steps
+  if num_steps <= 0:
+    raise ValueError('num_steps must be positive.')
   prediction = _rollout(model, initial_state, num_steps)
 
-  error = tf.reduce_mean((prediction - inputs['world_pos'])**2, axis=-1)
+  comparison_steps = min(num_steps, ground_truth_steps)
+  error = tf.reduce_mean(
+      (prediction[:comparison_steps] -
+       inputs['world_pos'][:comparison_steps])**2,
+      axis=-1)
   scalars = {'mse_%d_steps' % horizon: tf.reduce_mean(error[1:horizon+1])
              for horizon in [1, 10, 20, 50, 100, 200]}
   traj_ops = {
-      'faces': inputs['cells'],
-      'mesh_pos': inputs['mesh_pos'],
-      'gt_pos': inputs['world_pos'],
+      'faces': _resize_static_trajectory_field(inputs['cells'], num_steps),
+      'mesh_pos': _resize_static_trajectory_field(inputs['mesh_pos'], num_steps),
+      'gt_pos': inputs['world_pos'][:comparison_steps],
       'pred_pos': prediction
   }
   return scalars, traj_ops

--- a/meshgraphnets/plot_cfd.py
+++ b/meshgraphnets/plot_cfd.py
@@ -33,7 +33,7 @@ def main(unused_argv):
 
   fig, ax = plt.subplots(1, 1, figsize=(12, 8))
   skip = 10
-  num_steps = rollout_data[0]['gt_velocity'].shape[0]
+  num_steps = rollout_data[0]['pred_velocity'].shape[0]
   num_frames = len(rollout_data) * num_steps // skip
 
   # compute bounds

--- a/meshgraphnets/plot_cloth.py
+++ b/meshgraphnets/plot_cloth.py
@@ -34,7 +34,7 @@ def main(unused_argv):
   fig = plt.figure(figsize=(8, 8))
   ax = fig.add_subplot(111, projection='3d')
   skip = 10
-  num_steps = rollout_data[0]['gt_pos'].shape[0]
+  num_steps = rollout_data[0]['pred_pos'].shape[0]
   num_frames = len(rollout_data) * num_steps // skip
 
   # compute bounds

--- a/meshgraphnets/run_model.py
+++ b/meshgraphnets/run_model.py
@@ -41,6 +41,9 @@ flags.DEFINE_string('rollout_path', None,
 flags.DEFINE_enum('rollout_split', 'valid', ['train', 'test', 'valid'],
                   'Dataset split to use for rollouts.')
 flags.DEFINE_integer('num_rollouts', 10, 'No. of rollout trajectories')
+flags.DEFINE_integer(
+    'rollout_steps', 0,
+    'No. of rollout steps. Zero uses the dataset trajectory length.')
 flags.DEFINE_integer('num_training_steps', int(10e6), 'No. of training steps')
 
 PARAMETERS = {
@@ -87,10 +90,14 @@ def learner(model, params):
 
 def evaluator(model, params):
   """Run a model rollout trajectory."""
+  if FLAGS.rollout_steps < 0:
+    raise ValueError('rollout_steps must be non-negative.')
   ds = dataset.load_dataset(FLAGS.dataset_dir, FLAGS.rollout_split)
   ds = dataset.add_targets(ds, [params['field']], add_history=params['history'])
   inputs = tf.data.make_one_shot_iterator(ds).get_next()
-  scalar_op, traj_ops = params['evaluator'].evaluate(model, inputs)
+  rollout_steps = FLAGS.rollout_steps or None
+  scalar_op, traj_ops = params['evaluator'].evaluate(
+      model, inputs, num_steps=rollout_steps)
   tf.train.create_global_step()
 
   with tf.train.MonitoredTrainingSession(


### PR DESCRIPTION
## Summary

Allow MeshGraphNets evaluation rollouts to run for an explicit number of autoregressive steps instead of being limited to the ground-truth trajectory length.

Fixes #399.

`cfd_eval.evaluate` previously tied rollout length directly to `inputs['cells'].shape[0]`. Increasing the internal rollout length made the prediction longer than the target tensors, so evaluation failed when computing errors or fetching the saved trajectory.

This change:

- adds `--rollout_steps`; `0` preserves the dataset trajectory length
- threads an optional rollout length through both CFD and cloth evaluators, which share the same evaluation entry point
- computes MSE only for the overlap with available ground truth
- trims or extends the static mesh/topology trajectory fields to the prediction length so saved long rollouts remain self-contained
- updates CFD and cloth plotting scripts to use prediction length, allowing additional generated steps to be visualized
- rejects negative rollout lengths
- preserves existing behavior when the new flag is not set

## Validation

Added `meshgraphnets/cfd_eval_test.py` covering:

- unchanged default rollout length
- a 5-step prediction generated from a 3-step ground-truth trajectory
- extension of saved mesh/topology fields to the prediction length
- retention of ground truth for its original 3 steps
- expected autoregressive prediction values

I could not execute the TensorFlow regression test locally because TensorFlow is not installed in this environment. No local test execution is claimed. The final branch is based on current upstream `master`, contains one commit, and the diff was audited against upstream.