### PR TITLE
Use region-specific S3 endpoint for WikiText downloads

### DIFF
--- a/wikigraphs/scripts/download.sh
+++ b/wikigraphs/scripts/download.sh
@@ -29,11 +29,12 @@
 #
 # ==============================================================================
 BASE_DIR=/tmp/data
+WIKITEXT_BASE_URL="https://research.metamind.io.s3-us-west-2.amazonaws.com/wikitext"
 
 # wikitext-103
 TARGET_DIR=${BASE_DIR}/wikitext-103
 mkdir -p ${TARGET_DIR}
-wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-v1.zip -P ${TARGET_DIR}
+wget "${WIKITEXT_BASE_URL}/wikitext-103-v1.zip" -P ${TARGET_DIR}
 unzip ${TARGET_DIR}/wikitext-103-v1.zip -d ${TARGET_DIR}
 mv ${TARGET_DIR}/wikitext-103/* ${TARGET_DIR}
 rm -rf ${TARGET_DIR}/wikitext-103 ${TARGET_DIR}/wikitext-103-v1.zip
@@ -41,7 +42,7 @@ rm -rf ${TARGET_DIR}/wikitext-103 ${TARGET_DIR}/wikitext-103-v1.zip
 # wikitext-103-raw
 TARGET_DIR=${BASE_DIR}/wikitext-103-raw
 mkdir -p ${TARGET_DIR}
-wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip -P ${TARGET_DIR}
+wget "${WIKITEXT_BASE_URL}/wikitext-103-raw-v1.zip" -P ${TARGET_DIR}
 unzip ${TARGET_DIR}/wikitext-103-raw-v1.zip -d ${TARGET_DIR}
 mv ${TARGET_DIR}/wikitext-103-raw/* ${TARGET_DIR}
 rm -rf ${TARGET_DIR}/wikitext-103-raw ${TARGET_DIR}/wikitext-103-raw-v1.zip


### PR DESCRIPTION
## Summary

Update the WikiGraphs download script to fetch WikiText-103 from the bucket's region-specific S3 endpoint.

The existing `s3.amazonaws.com/research.metamind.io/...` URLs now fail for users with redirect/403 errors because the bucket requires its regional endpoint. The same stale host is used for both the tokenized and raw WikiText-103 archives.

This change:
- defines the region-specific WikiText S3 base URL once
- uses it for `wikitext-103-v1.zip`
- uses it for `wikitext-103-raw-v1.zip`
- leaves extraction paths, licensing text, and Freebase downloads unchanged

Fixes #604.
Also addresses the same WikiText download failure reported in #496 and #575.

## Validation

The branch is based on current upstream `master` and contains one commit changing only `wikigraphs/scripts/download.sh`.

`bash -n` passes for the updated script. The full archives were not downloaded locally because they are large; no full dataset-download test is claimed.