### PR TITLE
Use supported scikit-learn package name

### DIFF
--- a/learning_to_simulate/requirements.txt
+++ b/learning_to_simulate/requirements.txt
@@ -4,6 +4,6 @@ tensorflow>=1.15,<2
 numpy
 dm-sonnet<2
 tensorflow_probability<0.9
-sklearn
+scikit-learn
 dm-tree
 matplotlib


### PR DESCRIPTION
## Summary

Replace the deprecated `sklearn` PyPI dependency in `learning_to_simulate/requirements.txt` with the supported package name, `scikit-learn`.

The code imports the `sklearn` module, but the installable distribution is `scikit-learn`. The legacy `sklearn` shim now aborts installation and instructs users to depend on `scikit-learn` instead, which is the failure reported in #427.

This change only updates the distribution name. Python imports and runtime behaviour are unchanged.

Fixes #427.

## Validation

The final branch is based on current upstream `master` and contains one commit changing one line in `learning_to_simulate/requirements.txt`.

No runtime test is required for this package-name-only dependency correction; no test execution is claimed.