### PR TITLE
Clarify Learning to Simulate sequence length metadata

### DIFF
--- a/learning_to_simulate/README.md
+++ b/learning_to_simulate/README.md
@@ -69,6 +69,13 @@ Datasets are available to download via:
 
   `https://storage.googleapis.com/learning-to-simulate-complex-physics/Datasets/{DATASET_NAME}/{DATASET_SPLIT}.tfrecord`
 
+The metadata `sequence_length` is the number of simulation transitions used by
+the dataset. Each serialized position trajectory contains
+`sequence_length + 1` frames because an additional initial frame is needed to
+compute the first position change. For example, `sequence_length: 600`
+corresponds to 601 position frames. `reading_utils.py` accounts for this extra
+frame when reshaping positions and per-step context.
+
 Where:
 
 * `{DATASET_SPLIT}` is one of:


### PR DESCRIPTION
## Summary

Clarify why `sequence_length` in Learning to Simulate metadata is one less than the number of serialized position frames.

The dataset reader explicitly reshapes positions to `metadata['sequence_length'] + 1` because the serialized trajectory includes an additional initial frame. That extra frame is needed to compute the first position change, while `sequence_length` counts the simulation transitions used by the dataset.

This documentation change adds that relationship to the Dataset section and gives the concrete example that `sequence_length: 600` corresponds to 601 position frames.

Fixes #597.

## Validation

Documentation-only change. Verified the explanation against `learning_to_simulate/reading_utils.py`, which explicitly uses `metadata['sequence_length'] + 1` for positions and per-step context.

The final branch is based on current upstream `master`, contains one commit, and changes only `learning_to_simulate/README.md` with 7 added lines.