### PR TITLE
Document Enformer ambiguity and lowercase base encoding

### DIFF
--- a/enformer/README.md
+++ b/enformer/README.md
@@ -83,6 +83,13 @@ one hot encoded using the order of indices being 'ACGT' with N values being all
 zeros. Note that only the central 196,608 bp of the input sequence will be used
 by the Enformer model. The rest will be cropped within the model.
 
+`one_hot_encode` assigns non-zero vectors only to the uppercase canonical bases
+`A`, `C`, `G`, and `T`. `N` is encoded as all zeros, and characters that are not
+in the canonical alphabet also remain all zeros. This includes IUPAC ambiguity
+codes such as `R`, `Y`, and `M`, and lowercase soft-masked bases such as `a`,
+`c`, `g`, and `t`. Convert lowercase sequence to uppercase before encoding if
+soft masking should not change the canonical base identity.
+
 ```python
 import tensorflow as tf
 import tensorflow_hub as hub


### PR DESCRIPTION
## Summary

Document how Enformer's `one_hot_encode` helper handles IUPAC ambiguity codes and lowercase soft-masked bases.

The implementation initializes the encoding table to zeros and assigns non-zero one-hot vectors only to the uppercase canonical alphabet `ACGT`. `N` is explicitly neutral, and other characters therefore remain all-zero vectors as well. This includes IUPAC ambiguity codes such as `R`, `Y`, and `M`, plus lowercase `a`, `c`, `g`, and `t`.

This change makes that behaviour explicit in the inference documentation and notes that callers should uppercase soft-masked sequence first when lowercase bases should retain their canonical identity.

Fixes #695.

## Validation

Documentation-only change. Verified directly against `enformer.one_hot_encode` in `enformer/enformer.py`.

The final branch is based on current upstream `master`, contains one commit, and changes only `enformer/README.md` with 7 added lines.