### PR TITLE
Use configured MeshGraphNets training batch size

### DIFF
--- a/meshgraphnets/run_model.py
+++ b/meshgraphnets/run_model.py
@@ -58,6 +58,7 @@ def learner(model, params):
   ds = dataset.split_and_preprocess(ds, noise_field=params['field'],
                                     noise_scale=params['noise'],
                                     noise_gamma=params['gamma'])
+  ds = dataset.batch_dataset(ds, params['batch'])
   inputs = tf.data.make_one_shot_iterator(ds).get_next()
 
   loss_op = model.loss(inputs)


### PR DESCRIPTION
## Summary

Apply the per-model `batch` setting in the MeshGraphNets training pipeline.

`PARAMETERS` defines `batch=2` for the CFD model and `batch=1` for the cloth model, and `dataset.py` provides `batch_dataset` to merge graph examples while renumbering cell indices. However, `learner()` currently never calls that helper, so the configured CFD batch size is ignored and training always consumes one frame at a time.

This change passes the preprocessed training dataset through `dataset.batch_dataset(ds, params['batch'])` before constructing the iterator. Cloth behavior is unchanged because its configured batch size is 1.

Fixes #424.

## Validation

The final branch is based on current upstream `master`, contains one commit, and changes exactly one line in `meshgraphnets/run_model.py`.

The change uses the existing `batch_dataset` implementation and the already-defined per-model `batch` parameter. TensorFlow 1.x is not installed in this execution environment, so no runtime training test is claimed.