### PR TITLE
Clarify Enformer sequence length configuration

### DIFF
--- a/enformer/README.md
+++ b/enformer/README.md
@@ -83,6 +83,21 @@ one hot encoded using the order of indices being 'ACGT' with N values being all
 zeros. Note that only the central 196,608 bp of the input sequence will be used
 by the Enformer model. The rest will be cropped within the model.
 
+### Sequence length
+
+Two sequence lengths appear in the released examples. The TensorFlow Hub wrapper
+accepts 393,216 bp and crops to the central 196,608 bp used by the Enformer
+network. In the source implementation, `SEQUENCE_LENGTH = 196_608` is also part
+of the `predict_on_batch` SavedModel input signature. After the stem and six
+convolutional pooling stages, the trunk is cropped to `TARGET_LENGTH = 896`
+prediction bins.
+
+For the published pre-trained model, pad or crop inputs to the expected length
+rather than changing `SEQUENCE_LENGTH`. Changing that constant alone changes the
+SavedModel signature but does not retrain the model or redefine the published
+input/output geometry. Experiments with a different context length should be
+trained and validated as a modified model configuration.
+
 ```python
 import tensorflow as tf
 import tensorflow_hub as hub


### PR DESCRIPTION
## Summary

Clarify the different sequence lengths used by the released Enformer examples and what can safely be changed.

The TensorFlow Hub example accepts 393,216 bp and crops to the central 196,608 bp used by the network. In the source implementation, `SEQUENCE_LENGTH = 196_608` is also part of the `predict_on_batch` SavedModel input signature. The trunk subsequently downsamples the sequence and crops to `TARGET_LENGTH = 896` output bins.

The new documentation explains that users of the published pre-trained model should pad or crop inputs to the expected length rather than changing `SEQUENCE_LENGTH`. A different context length is a modified model configuration that should be trained and validated accordingly.

Fixes #517.

## Validation

Documentation-only change. Verified against the current `SEQUENCE_LENGTH` and `TARGET_LENGTH` constants, the `predict_on_batch` input signature, and `TargetLengthCrop1D` in `enformer/enformer.py`.

The final branch is based on current upstream `master`, contains one commit, and changes only `enformer/README.md`.