### PR TITLE
Use HTTPS for OGB-LSC git dependencies

### DIFF
--- a/ogb_lsc/mag/requirements.txt
+++ b/ogb_lsc/mag/requirements.txt
@@ -13,11 +13,11 @@ tensorflow-datasets>=4.3.0
 dm-tree>=0.1.6
 ogb>=1.3.1
 # graph_nets
-git+git://github.com/deepmind/graph_nets.git@64771dff0d74ca8e77b1f1dcd5a7d26634356d61
+git+https://github.com/google-deepmind/graph_nets.git@64771dff0d74ca8e77b1f1dcd5a7d26634356d61
 scipy>=1.2.1
 jaxlib>=0.1.67+cuda110
 tqdm>=4.28.1
 annoy>=1.0.3
 # jraph
-git+git://github.com/deepmind/jraph.git@80d2f9e4d82f841a71d56ba44fa9e8781e93ae1f
+git+https://github.com/google-deepmind/jraph.git@80d2f9e4d82f841a71d56ba44fa9e8781e93ae1f
 google-cloud-storage


### PR DESCRIPTION
## Summary

Fix OGB-LSC MAG dependency installation where the requirements file still uses the unauthenticated `git://` transport for Graph Nets and Jraph.

The failing path reported in #392 comes from pip invoking `git clone` through `git://github.com/...`. The repositories are available through HTTPS and have since moved to the `google-deepmind` organization.

This change:
- replaces the Graph Nets `git://` URL with its canonical HTTPS clone URL
- replaces the Jraph `git://` URL with its canonical HTTPS clone URL
- preserves both exact pinned commit SHAs
- leaves all package versions and other dependencies unchanged

Fixes #392.

## Validation

Verified that both canonical repositories exist and that the pinned commits are present:
- Graph Nets: `64771dff0d74ca8e77b1f1dcd5a7d26634356d61`
- Jraph: `80d2f9e4d82f841a71d56ba44fa9e8781e93ae1f`

A full legacy OGB-LSC environment installation was not run, so no full installation pass is claimed.

The final branch is based directly on current upstream `master`, contains one commit (`edb99101ea40ebbcf9270d1f6e6b26b9473ac68f`), and changes only two lines in `ogb_lsc/mag/requirements.txt`.