### PR TITLE
Document supported Python versions for Learning to Simulate

### DIFF
--- a/learning_to_simulate/README.md
+++ b/learning_to_simulate/README.md
@@ -36,7 +36,7 @@ For example, with Python 3.7 available as `python3.7`:
     python3.7 -m venv /tmp/learning_to_simulate_venv
     source /tmp/learning_to_simulate_venv/bin/activate
     pip install -r learning_to_simulate/requirements.txt
-    mkdir -p /tmp/rollous
+    mkdir -p /tmp/rollouts
 
 Download dataset (e.g. WaterRamps):
 

--- a/learning_to_simulate/README.md
+++ b/learning_to_simulate/README.md
@@ -25,8 +25,16 @@ If you use the code here please cite this paper:
 
 ![WaterRamps rollout](images/water_ramps_rollout.gif)
 
-After downloading the repo, and from the parent directory. Install dependencies:
+After downloading the repo, and from the parent directory. This reference
+implementation depends on TensorFlow 1.15, whose published Python wheels support
+Python 3.6 and 3.7. Use one of those Python versions when creating the
+environment; newer Python versions cannot install the pinned TensorFlow 1.x
+runtime from PyPI.
 
+For example, with Python 3.7 available as `python3.7`:
+
+    python3.7 -m venv /tmp/learning_to_simulate_venv
+    source /tmp/learning_to_simulate_venv/bin/activate
     pip install -r learning_to_simulate/requirements.txt
     mkdir -p /tmp/rollous
 


### PR DESCRIPTION
## Summary

Document the Python-version constraint required by Learning to Simulate's TensorFlow 1.15 dependency.

The current setup instructions run `pip install -r learning_to_simulate/requirements.txt` without stating that the requirements pin TensorFlow to the 1.15 line. Users on newer Python versions therefore reach `No matching distribution found for tensorflow<2,>=1.15`, as reported in #417.

This change:
- states that the released reference environment uses Python 3.6 or 3.7
- explains why newer Python versions cannot install the required TensorFlow 1.15 wheel from PyPI
- adds a concrete Python 3.7 virtual-environment setup example
- leaves the dependency versions and runtime code unchanged
- corrects the rollout-directory typo in the setup example (`/tmp/rollous` → `/tmp/rollouts`)

Fixes #417.

## Validation

The branch is based on current upstream `master` and changes only `learning_to_simulate/README.md`.