### PR TITLE
Avoid NaNs from roundoff in MeshGraphNets normalization

### DIFF
--- a/meshgraphnets/normalization.py
+++ b/meshgraphnets/normalization.py
@@ -68,5 +68,10 @@ class Normalizer(snt.AbstractModule):
 
   def _std_with_epsilon(self):
     safe_count = tf.maximum(self._acc_count, 1.)
-    std = tf.sqrt(self._acc_sum_squared / safe_count - self._mean()**2)
+    variance = self._acc_sum_squared / safe_count - self._mean()**2
+    # Roundoff in E[x^2] - E[x]^2 can make a mathematically non-negative
+    # variance slightly negative. Clamp before sqrt so that this does not
+    # propagate a NaN through normalization.
+    variance = tf.maximum(variance, 0.)
+    std = tf.sqrt(variance)
     return tf.math.maximum(std, self._std_epsilon)

--- a/meshgraphnets/normalization_test.py
+++ b/meshgraphnets/normalization_test.py
@@ -1,0 +1,45 @@
+# pylint: disable=g-bad-file-header
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or  implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for MeshGraphNets online normalization."""
+
+import tensorflow.compat.v1 as tf
+
+from meshgraphnets import normalization
+
+
+class NormalizerTest(tf.test.TestCase):
+
+  def test_roundoff_negative_variance_does_not_produce_nan(self):
+    normalizer = normalization.Normalizer(size=1, std_epsilon=1e-8)
+    std = normalizer._std_with_epsilon()
+
+    # These accumulated statistics produce a small negative value for
+    # E[x^2] - E[x]^2, as can happen from floating-point roundoff.
+    set_stats = tf.group(
+        tf.assign(normalizer._acc_count, 1.),
+        tf.assign(normalizer._acc_sum, [1.0000001]),
+        tf.assign(normalizer._acc_sum_squared, [1.]))
+
+    with self.session() as sess:
+      sess.run(tf.global_variables_initializer())
+      sess.run(set_stats)
+      result = sess.run(std)
+
+    self.assertAllClose(result, [1e-8])
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
## Summary

Prevent MeshGraphNets' online normalizer from producing NaNs when floating-point roundoff makes the computed variance slightly negative.

The normalizer computes variance using `E[x^2] - E[x]^2`. For nearly constant features, finite-precision accumulation can make that expression a small negative number even though the mathematical variance is non-negative. The current implementation applies `sqrt` first and only then clamps the resulting standard deviation, so a negative intermediate value becomes NaN and the later `maximum` cannot recover it.

This change:
- computes the variance explicitly
- clamps variance to zero before taking the square root
- preserves the existing `std_epsilon` floor
- adds a regression test using accumulated statistics that reproduce a small negative roundoff variance

Fixes #346.

## Validation

Added `meshgraphnets/normalization_test.py` with a focused regression case verifying that a small negative roundoff variance produces `std_epsilon` rather than NaN.

TensorFlow/Sonnet matching this legacy environment are not installed in the execution environment, so the regression test was not executed locally and no local test pass is claimed.

The final branch is based directly on current upstream `master`, contains one commit (`9411f4e6bb1693c31013db1fe7c384b02b993313`), and changes only `meshgraphnets/normalization.py` plus its regression test.