### PR TITLE
Pin TensorFlow Probability for PolyGen

### DIFF
--- a/polygen/setup.py
+++ b/polygen/setup.py
@@ -23,7 +23,8 @@ from setuptools import setup
 
 
 REQUIRED_PACKAGES = ['numpy', 'dm-sonnet==1.36', 'tensorflow==1.14',
-                     'tensor2tensor==1.15', 'networkx', 'matplotlib', 'six']
+                     'tensorflow-probability==0.7.0', 'tensor2tensor==1.15',
+                     'networkx', 'matplotlib', 'six']
 
 setup(
     name='polygen',


### PR DESCRIPTION
## Summary

Pin TensorFlow Probability to the release compatible with PolyGen's TensorFlow 1.14 environment.

`polygen/setup.py` pins `tensorflow==1.14` and `dm-sonnet==1.36` but leaves TensorFlow Probability implicit. A fresh installation can therefore resolve TensorFlow Probability 0.8, which requires TensorFlow 1.15 and fails at import time with the incompatibility reported in #411.

This change adds `tensorflow-probability==0.7.0` to PolyGen's explicit dependencies while leaving the rest of the historical environment unchanged.

Fixes #411.

## Validation

The final branch is based directly on current upstream `master` and contains one commit (`66b854d93d0d22237f29d9a0dc194aff41feb21f`).

The final diff changes only `polygen/setup.py`, adding the TensorFlow Probability pin.

The full historical TensorFlow 1.14 environment was not installed in this execution environment, so no end-to-end installation or test pass is claimed.