### PR TITLE
Support configurable Enformer output heads

### DIFF
--- a/enformer/README.md
+++ b/enformer/README.md
@@ -124,6 +124,18 @@ full sonnet module is defined in `enformer.py` called Enformer. See
 on how to train the model on Basenji2 data and how to load the pre-trained
 weights into the Enformer module for fine-tuning.
 
+The source model defaults to the published human and mouse output heads. To
+train Enformer with a different set of target tracks, pass a mapping from output
+head name to the number of tracks, for example:
+
+```python
+model = Enformer(heads_channels={'pig': num_pig_tracks})
+```
+
+This changes the output-head configuration only. A new head does not have
+weights in the published human/mouse checkpoint and therefore needs to be
+trained for the corresponding targets.
+
 ## Colab
 
 Further usage and training examples are given in the following colab notebooks:

--- a/enformer/enformer.py
+++ b/enformer/enformer.py
@@ -27,7 +27,7 @@ Pushmeet Kohli1, David R. Kelley2*
 * correspondence: avsec@google.com, pushmeet@google.com, drk@calicolabs.com
 """
 import inspect
-from typing import Any, Callable, Dict, Optional, Text, Union, Iterable
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Text, Union
 
 import attention_module
 import numpy as np
@@ -47,7 +47,8 @@ class Enformer(snt.Module):
                num_transformer_layers: int = 11,
                num_heads: int = 8,
                pooling_type: str = 'attention',
-               name: str = 'enformer'):
+               name: str = 'enformer',
+               heads_channels: Optional[Mapping[str, int]] = None):
     """Enformer model.
 
     Args:
@@ -57,10 +58,17 @@ class Enformer(snt.Module):
       num_heads: Number of attention heads.
       pooling_type: Which pooling function to use. Options: 'attention' or max'.
       name: Name of sonnet module.
+      heads_channels: Mapping from output head names to numbers of target tracks.
+        Defaults to the published human and mouse heads.
     """
     super().__init__(name=name)
     # pylint: disable=g-complex-comprehension,g-long-lambda,cell-var-from-loop
-    heads_channels = {'human': 5313, 'mouse': 1643}
+    if heads_channels is None:
+      heads_channels = {'human': 5313, 'mouse': 1643}
+    elif not heads_channels:
+      raise ValueError('heads_channels must contain at least one output head.')
+    else:
+      heads_channels = dict(heads_channels)
     dropout_rate = 0.4
     assert channels % num_heads == 0, ('channels needs to be divisible '
                                        f'by {num_heads}')

--- a/enformer/enformer_test.py
+++ b/enformer/enformer_test.py
@@ -34,6 +34,21 @@ class TestEnformer(unittest.TestCase):
     self.assertEqual(outputs['human'].shape, (1, enformer.TARGET_LENGTH, 5313))
     self.assertEqual(outputs['mouse'].shape, (1, enformer.TARGET_LENGTH, 1643))
 
+  def test_custom_heads(self):
+    model = enformer.Enformer(
+        channels=1536,
+        num_transformer_layers=11,
+        name='enformer_pig',
+        heads_channels={'pig': 17})
+    self.assertEqual(set(model.heads), {'pig'})
+    head_inputs = np.zeros((1, 2, 3072), dtype=np.float32)
+    outputs = model.heads['pig'](head_inputs, is_training=False)
+    self.assertEqual(outputs.shape, (1, 2, 17))
+
+  def test_empty_heads_rejected(self):
+    with self.assertRaises(ValueError):
+      enformer.Enformer(heads_channels={})
+
 
 def _get_random_input():
   seq = ''.join(


### PR DESCRIPTION
## Summary

Allow the source Enformer model to configure output heads instead of hard-coding only the published human and mouse track counts.

The implementation currently creates `{'human': 5313, 'mouse': 1643}` inside `Enformer.__init__`, which means users adapting the architecture to another species cannot specify a different target set without editing the model source. This is the limitation raised in #297.

This change:
- adds an optional `heads_channels` mapping to `Enformer.__init__`
- preserves the existing human and mouse heads by default
- preserves the existing positional constructor arguments by adding the new option after `name`
- rejects an empty head mapping
- adds focused tests for a custom `pig` head and the empty-mapping case
- documents that newly configured heads need training because the published checkpoint contains only the published heads

Fixes #297.

## Validation

The final branch is based directly on current upstream `master` and contains one commit (`3f3400ec93d7fdc8aa5dcc64dda8c230b104534d`).

The final diff changes only:
- `enformer/enformer.py`
- `enformer/enformer_test.py`
- `enformer/README.md`

The legacy Enformer/TensorFlow dependency stack is not installed in this execution environment, so the tests were not executed locally and no local test pass is claimed.